### PR TITLE
Replace raw rgbmatrix with RGBMatrixDriver and optional software emulation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 
 .DS_Store
+__pycache__
+emulator_config.json

--- a/install.sh
+++ b/install.sh
@@ -14,7 +14,7 @@ git checkout master
 git fetch origin --prune
 git pull
 sudo apt-get install libxml2-dev libxslt-dev
-sudo pip install pytz tzlocal requests
+sudo pip install pytz tzlocal requests "RGBMatrixDriver>=0.1.2"
 make
 echo "If you didn't see any errors above, everything should be installed!"
 echo "Installation complete! Play around with the examples in matrix/bindings/python/samples to make sure your matrix is working."

--- a/main.py
+++ b/main.py
@@ -1,22 +1,19 @@
 from datetime import datetime, timedelta
 from data.scoreboard_config import ScoreboardConfig
 from renderer.main import MainRenderer
-from rgbmatrix import RGBMatrix, RGBMatrixOptions
-from utils import args, led_matrix_options
+from RGBMatrixDriver import RGBMatrix, RGBMatrixOptions, prefilled_matrix_options
+from utils import args
 from data.data import Data
 import debug
 
 SCRIPT_NAME = "NBA Scoreboard"
 SCRIPT_VERSION = "1.0.0"
 
-# Get supplied command line arguments
-args = args()
-
 # Check for led configuration arguments
-matrixOptions = led_matrix_options(args)
+command_line_args = args()
 
 # Initialize the matrix
-matrix = RGBMatrix(options = matrixOptions)
+matrix = RGBMatrix(options=prefilled_matrix_options(command_line_args))
 
 # Print some basic info on startup
 debug.info("{} - v{} ({}x{})".format(SCRIPT_NAME, SCRIPT_VERSION, matrix.width, matrix.height))

--- a/matrix/bindings/python/README.md
+++ b/matrix/bindings/python/README.md
@@ -126,7 +126,7 @@ options.hardware_mapping = 'regular'  # If you have an Adafruit HAT: 'adafruit-h
 matrix = RGBMatrix(options = options)
 
 # Make image fit our screen.
-image.thumbnail((matrix.width, matrix.height), Image.ANTIALIAS)
+image.thumbnail((matrix.width, matrix.height), Image.LANCZOS)
 
 matrix.SetImage(image.convert('RGB'))
 

--- a/matrix/bindings/python/samples/graphics.py
+++ b/matrix/bindings/python/samples/graphics.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 from samplebase import SampleBase
-from rgbmatrix import graphics
+from RGBMatrixDriver import graphics
 import time
 
 

--- a/matrix/bindings/python/samples/image-draw.py
+++ b/matrix/bindings/python/samples/image-draw.py
@@ -9,7 +9,7 @@
 # Note that PIL graphics do not have an immediate effect on the display --
 # image is drawn into a separate buffer, which is then copied to the matrix
 # using the SetImage() function (see examples below).
-# Requires RGBMatrixDriver.so present in the same directory.
+# Requires rgbmatrix.so present in the same directory.
 
 # PIL Image module (create or load images) is explained here:
 # http://effbot.org/imagingbook/image.htm

--- a/matrix/bindings/python/samples/image-draw.py
+++ b/matrix/bindings/python/samples/image-draw.py
@@ -9,7 +9,7 @@
 # Note that PIL graphics do not have an immediate effect on the display --
 # image is drawn into a separate buffer, which is then copied to the matrix
 # using the SetImage() function (see examples below).
-# Requires rgbmatrix.so present in the same directory.
+# Requires RGBMatrixDriver.so present in the same directory.
 
 # PIL Image module (create or load images) is explained here:
 # http://effbot.org/imagingbook/image.htm
@@ -19,7 +19,7 @@
 from PIL import Image
 from PIL import ImageDraw
 import time
-from rgbmatrix import RGBMatrix, RGBMatrixOptions
+from RGBMatrixDriver import RGBMatrix, RGBMatrixOptions
 
 # Configuration for the matrix
 options = RGBMatrixOptions()

--- a/matrix/bindings/python/samples/image-scroller.py
+++ b/matrix/bindings/python/samples/image-scroller.py
@@ -12,7 +12,7 @@ class ImageScroller(SampleBase):
     def run(self):
         if not 'image' in self.__dict__:
             self.image = Image.open(self.args.image).convert('RGB')
-        self.image.resize((self.matrix.width, self.matrix.height), Image.ANTIALIAS)
+        self.image.resize((self.matrix.width, self.matrix.height), Image.LANCZOS)
 
         double_buffer = self.matrix.CreateFrameCanvas()
         img_width, img_height = self.image.size

--- a/matrix/bindings/python/samples/image-viewer.py
+++ b/matrix/bindings/python/samples/image-viewer.py
@@ -2,7 +2,7 @@
 import time
 import sys
 
-from rgbmatrix import RGBMatrix, RGBMatrixOptions
+from RGBMatrixDriver import RGBMatrix, RGBMatrixOptions
 from PIL import Image
 
 if len(sys.argv) < 2:
@@ -22,7 +22,7 @@ options.hardware_mapping = 'regular'  # If you have an Adafruit HAT: 'adafruit-h
 matrix = RGBMatrix(options = options)
 
 # Make image fit our screen.
-image.thumbnail((matrix.width, matrix.height), Image.ANTIALIAS)
+image.thumbnail((matrix.width, matrix.height), Image.LANCZOS)
 
 matrix.SetImage(image.convert('RGB'))
 

--- a/matrix/bindings/python/samples/runtext.py
+++ b/matrix/bindings/python/samples/runtext.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # Display a runtext with double-buffering.
 from samplebase import SampleBase
-from rgbmatrix import graphics
+from RGBMatrixDriver import graphics
 import time
 
 

--- a/matrix/bindings/python/samples/samplebase.py
+++ b/matrix/bindings/python/samples/samplebase.py
@@ -4,7 +4,7 @@ import sys
 import os
 
 sys.path.append(os.path.abspath(os.path.dirname(__file__) + '/..'))
-from rgbmatrix import RGBMatrix, RGBMatrixOptions
+from RGBMatrixDriver import RGBMatrix, RGBMatrixOptions
 
 
 class SampleBase(object):

--- a/renderer/main.py
+++ b/renderer/main.py
@@ -1,6 +1,6 @@
 from PIL import Image, ImageFont, ImageDraw, ImageSequence
-from rgbmatrix import graphics
-from utils import center_text
+from RGBMatrixDriver import graphics
+from utils import center_text, getsize
 from calendar import month_abbr
 from renderer.screen_config import screenConfig
 from datetime import datetime, timedelta
@@ -32,7 +32,7 @@ class MainRenderer:
         self.draw = ImageDraw.Draw(self.image)
 
     def display_nba_logo(self):
-        nba_logo = Image.open('logos/NBA.png').resize((22, 22), Image.ANTIALIAS)
+        nba_logo = Image.open('logos/NBA.png').resize((22, 22), Image.LANCZOS)
         self.canvas.SetImage(nba_logo.convert("RGB"), 22, 1)
 
     def display_team_logos(self, game, away_logo_position, home_logo_position):
@@ -45,8 +45,8 @@ class MainRenderer:
         """
         self.canvas.SetImage(self.image, 0, 0)
         if self.data.nba_logos:
-            away_team_logo = Image.open('logos/{}H.png'.format(game['awayteam'])).resize((20, 20), Image.ANTIALIAS)
-            home_team_logo = Image.open('logos/{}H.png'.format(game['hometeam'])).resize((20, 20), Image.ANTIALIAS)
+            away_team_logo = Image.open('logos/{}H.png'.format(game['awayteam'])).resize((20, 20), Image.LANCZOS)
+            home_team_logo = Image.open('logos/{}H.png'.format(game['hometeam'])).resize((20, 20), Image.LANCZOS)
         else:
             away_team_logo = Image.open('logos/{}.png'.format(game['awayteam'])).resize((20, 20), Image.BOX)
             home_team_logo = Image.open('logos/{}.png'.format(game['hometeam'])).resize((20, 20), Image.BOX)
@@ -139,7 +139,7 @@ class MainRenderer:
 
 
     def loading(self):
-        loading_pos = center_text(self.font_mini.getsize('Loading')[0], 32)
+        loading_pos = center_text(getsize(self.font_mini, 'Loading'), 32)
         self.draw.multiline_text((loading_pos, 24), 'Loading...', font=self.font_mini, align="center")
         self.canvas.SetImage(self.image, 0, 0)
         self.display_nba_logo()
@@ -182,8 +182,8 @@ class MainRenderer:
         game_time = game_datetime.strftime("%-I:%M %p")
 
         # Center the game time on screen
-        date_pos = center_text(self.font_mini.getsize(date_text)[0], 32)
-        game_time_pos = center_text(self.font_mini.getsize(game_time)[0], 32)
+        date_pos = center_text(getsize(self.font_mini, date_text), 32)
+        game_time_pos = center_text(getsize(self.font_mini, game_time), 32)
 
         # Draw the text on the Data image
         self.draw.text((date_pos, 0), date_text, font=self.font_mini)
@@ -217,7 +217,7 @@ class MainRenderer:
                 countdown = ':'.join(str(remaining_time).split(':')[1:]).split('.')[0]
 
             # Center the countdown on screen
-            countdown_pos = center_text(self.font_mini.getsize(countdown)[0], 32)
+            countdown_pos = center_text(getsize(self.font_mini, countdown), 32)
 
             # Draw the countdown text
             self.draw.text((29, 0), 'IN', font=self.font_mini)
@@ -251,13 +251,13 @@ class MainRenderer:
         # Set the position of the information on screen.
         homescore = '{0:02d}'.format(homescore)
         awayscore = '{0:02d}'.format(awayscore)
-        home_score_size = self.font.getsize(homescore)[0]
-        home_score_pos = center_text(self.font.getsize(homescore)[0], 16)
-        away_score_pos = center_text(self.font.getsize(awayscore)[0], 48)
-        time_period_pos = center_text(self.font_mini.getsize(time_period)[0], 32)
-        # score_position = center_text(self.font.getsize(score)[0], 32)
-        quarter_position = center_text(self.font_mini.getsize(quarter)[0], 32)
-        # info_pos = center_text(self.font_mini.getsize(pos)[0], 32)
+        home_score_size = getsize(self.font, homescore)
+        home_score_pos = center_text(getsize(self.font, homescore), 16)
+        away_score_pos = center_text(getsize(self.font, awayscore), 48)
+        time_period_pos = center_text(getsize(self.font_mini, time_period), 32)
+        # score_position = center_text(getsize(self.font, score), 32)
+        quarter_position = center_text(getsize(self.font_mini, quarter), 32)
+        # info_pos = center_text(getsize(self.font_mini, pos), 32)
         # self.draw.multiline_text((info_pos, 13), pos, fill=pos_colour, font=self.font_mini, align="center")
 
         self.draw.multiline_text((quarter_position, 0), quarter, fill=(255, 255, 255), font=self.font_mini, align="center")
@@ -284,7 +284,7 @@ class MainRenderer:
         # Prepare the data
         score = '{}-{}'.format(game['awayscore'], game['homescore'])
         # Set the position of the information on screen.
-        score_position = center_text(self.font.getsize(score)[0], 32)
+        score_position = center_text(getsize(self.font, score), 32)
         # Draw the text on the Data image.
         self.draw.multiline_text((score_position, 19), score, fill=(255, 255, 255), font=self.font, align="center")
         self.draw.multiline_text((26, 0), "END", fill=(255, 255, 255), font=self.font_mini,align="center")

--- a/utils.py
+++ b/utils.py
@@ -1,11 +1,10 @@
-from rgbmatrix import RGBMatrixOptions, graphics
+from RGBMatrixDriver import RGBMatrixOptions, RGBMatrixArguments
 import collections
 import argparse
 import os
 import debug
 import datetime
 from tzlocal import get_localzone
-import pytz
 
 # get local timezone
 local_tz = get_localzone()
@@ -21,64 +20,10 @@ def split_string(string, num_chars):
   return [(string[i:i + num_chars]).strip() for i in range(0, len(string), num_chars)]
 
 def args():
-  parser = argparse.ArgumentParser()
+  sb_parser = RGBMatrixArguments()
+  sb_parser.add_argument("--fav-team", action="store", help="ID of the team to fallow. (Default:8 (Montreal Canadien)) Change the default in the config.json", type=int)
 
-  # Options for the rpi-rgb-led-matrix library
-  parser.add_argument("--led-rows", action="store", help="Display rows. 16 for 16x32, 32 for 32x32. (Default: 32)", default=32, type=int)
-  parser.add_argument("--led-cols", action="store", help="Panel columns. Typically 32 or 64. (Default: 64)", default=64, type=int)
-  parser.add_argument("--led-chain", action="store", help="Daisy-chained boards. (Default: 1)", default=1, type=int)
-  parser.add_argument("--led-parallel", action="store", help="For Plus-models or RPi2: parallel chains. 1..3. (Default: 1)", default=1, type=int)
-  parser.add_argument("--led-pwm-bits", action="store", help="Bits used for PWM. Range 1..11. (Default: 11)", default=11, type=int)
-  parser.add_argument("--led-brightness", action="store", help="Sets brightness level. Range: 1..100. (Default: 100)", default=100, type=int)
-  parser.add_argument("--led-gpio-mapping", help="Hardware Mapping: regular, adafruit-hat, adafruit-hat-pwm" , choices=['regular', 'adafruit-hat', 'adafruit-hat-pwm'], type=str)
-  parser.add_argument("--led-scan-mode", action="store", help="Progressive or interlaced scan. 0 = Progressive, 1 = Interlaced. (Default: 1)", default=1, choices=range(2), type=int)
-  parser.add_argument("--led-pwm-lsb-nanoseconds", action="store", help="Base time-unit for the on-time in the lowest significant bit in nanoseconds. (Default: 130)", default=130, type=int)
-  parser.add_argument("--led-show-refresh", action="store_true", help="Shows the current refresh rate of the LED panel.")
-  parser.add_argument("--led-slowdown-gpio", action="store", help="Slow down writing to GPIO. Range: 0..4. (Default: 1)", choices=range(5), type=int)
-  parser.add_argument("--led-no-hardware-pulse", action="store", help="Don't use hardware pin-pulse generation.")
-  parser.add_argument("--led-rgb-sequence", action="store", help="Switch if your matrix has led colors swapped. (Default: RGB)", default="RGB", type=str)
-  parser.add_argument("--led-pixel-mapper", action="store", help="Apply pixel mappers. e.g \"Rotate:90\"", default="", type=str)
-  parser.add_argument("--led-row-addr-type", action="store", help="0 = default; 1 = AB-addressed panels. (Default: 0)", default=0, type=int, choices=[0,1])
-  parser.add_argument("--led-multiplexing", action="store", help="Multiplexing type: 0 = direct; 1 = strip; 2 = checker; 3 = spiral; 4 = Z-strip; 5 = ZnMirrorZStripe; 6 = coreman; 7 = Kaler2Scan; 8 = ZStripeUneven. (Default: 0)", default=0, type=int)
-
-  # User Options
-  parser.add_argument("--fav-team", action="store", help="ID of the team to fallow. (Default:8 (Montreal Canadien)) Change the default in the config.json", type=int)
-
-  return parser.parse_args()
-
-def led_matrix_options(args):
-  options = RGBMatrixOptions()
-
-  if args.led_gpio_mapping != None:
-    options.hardware_mapping = args.led_gpio_mapping
-
-  options.rows = args.led_rows
-  options.cols = args.led_cols
-  options.chain_length = args.led_chain
-  options.parallel = args.led_parallel
-  options.row_address_type = args.led_row_addr_type
-  options.multiplexing = args.led_multiplexing
-  options.pwm_bits = args.led_pwm_bits
-  options.brightness = args.led_brightness
-  options.pwm_lsb_nanoseconds = args.led_pwm_lsb_nanoseconds
-  options.led_rgb_sequence = args.led_rgb_sequence
-  try:
-    options.pixel_mapper_config = args.led_pixel_mapper
-  except AttributeError:
-    debug.warning("Your compiled RGB Matrix Library is out of date.")
-    debug.warning("The --led-pixel-mapper argument will not work until it is updated.")
-
-  if args.led_show_refresh:
-    options.show_refresh_rate = 1
-
-  if args.led_slowdown_gpio != None:
-    options.gpio_slowdown = args.led_slowdown_gpio
-
-  if args.led_no_hardware_pulse:
-    options.disable_hardware_pulsing = True
-
-  return options
-
+  return sb_parser.parse_args()
 
 def deep_update(source, overrides):
     """Update a nested dictionary or similar mapping.
@@ -96,3 +41,6 @@ def convert_time(utc_dt):
 
   local_dt = datetime.datetime.strptime(utc_dt, '%Y-%m-%dT%H:%M:%SZ').replace(tzinfo=pytz.utc).astimezone(local_tz)
   return local_tz.normalize(local_dt)  # .normalize might be unnecessary
+
+def getsize(font, text):
+    return font.font.getsize(text)[0][0]


### PR DESCRIPTION
I am the author of middleware for the RGB matrix libraries and maintainer for https://github.com/MLB-LED-Scoreboard/mlb-led-scoreboard.

https://github.com/ty-porter/RGBMatrixEmulator
https://github.com/ty-porter/RGBMatrixDriver

This PR inserts driver middleware and an emulation engine into the rendering stack.
The driver simplifies setup and running of these scripts, and includes utility functions like `--driver-fps=log`, which can emit an FPS counter.
The emulator is highly configurable to let you run the scoreboard in lots of different display adapters -- by default in the browser.

![Capture](https://github.com/m0ranwad/nba-led-scoreboard/assets/46663285/0d9ba24c-2abf-46d7-990e-750f0c23fcad)

Additionally:

* Addresses #16
  * Refactors broken `getsize` calls and converts `PIL.Image.ANTIALIAS` to `PIL.Image.LANCZOS`